### PR TITLE
Made menu items (Home, About, News, Projects) responsive with redirection to a new page with common elements (header and footer)

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -9,4 +9,3 @@ def get_data():
         "links": ["Explore More"]
     }
     return jsonify(data)
-

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import Layout from './components/Layout/Layout'; // Ensure this import path is correct
+import Layout from './components/Layout/Layout';
 import Home from './components/Home/Home';
 import News from './components/News/News';
 import Projects from './components/Projects/Projects';
@@ -9,14 +9,14 @@ import About from './components/About/About';
 function App() {
     return (
         <Router>
-            <Layout>
-                <Routes>
-                    <Route path="/" element={<Home />} />
-                    <Route path="/news" element={<News />} />
-                    <Route path="/projects" element={<Projects />} />
-                    <Route path="/about" element={<About />} />
-                </Routes>
-            </Layout>
+            <Routes>
+                <Route path="/" element={<Layout />}>
+                    <Route index element={<Home />} />
+                    <Route path="news" element={<News />} />
+                    <Route path="projects" element={<Projects />} />
+                    <Route path="about" element={<About />} />
+                </Route>
+            </Routes>
         </Router>
     );
 }

--- a/frontend/src/components/About/About.js
+++ b/frontend/src/components/About/About.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function About() {
+    return (
+        <div>
+            <h1>About Page</h1>
+            <p>This is the About page. More content coming soon.</p>
+        </div>
+    );
+}
+
+export default About;

--- a/frontend/src/components/Home/Home.css
+++ b/frontend/src/components/Home/Home.css
@@ -153,32 +153,3 @@ body {
     font-size: 14px;
     color: #ccc;
   }
-
-
-/* 
-.content {
-    display: flex;
-    padding: 20px;
-}
-
-
-.right-content {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    padding-right: 20px;
-    text-align: center;
-}
-
-.flag-image {
-    width: 400px; 
-    height: auto;
-    margin: 0 auto 30px;
-    object-fit: cover;
-    /* clip-path: path('M 50,500 Q 350,-1350 800,500 Z');  */
-
-
-
-
-    
-

--- a/frontend/src/components/Layout/Layout.css
+++ b/frontend/src/components/Layout/Layout.css
@@ -91,81 +91,17 @@ main {
     flex-direction: column;
 }
 
-.content {
-    display: flex;
-    padding: 20px;
-}
-
-.left-image {
-    padding: 0; 
-    margin: 0; 
-}
-
-.left-image img {
-    width: 80%;  
-    height: 100%; 
-    object-fit: cover; 
-    padding: 0; 
-    margin: 0;  
-    display: block; 
-}
-
-
-.right-content {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    padding: 80px;
-    text-align: center;
-}
-
-.flag-image {
-    width: 500px; 
-    height: auto;
-    margin: 0 auto 30px;
-    object-fit: cover;
-    /* clip-path: path('M 50,500 Q 350,-1350 800,500 Z');  */
-}
-
-
-.cta-button {
-    padding: 10px 20px; 
-    background-color: #04287a; 
-    color: white; 
-    cursor: pointer;
-    margin: 10px auto 0; 
-    border-radius: 30px; 
-    font-size: 16px;
-    border: 1px solid rgba(255, 255, 255, 0.5); 
-    text-align: center;
-    width: fit-content; 
-    height: 50px;
-    transition: background-color 0.3s, border 0.3s; 
-}
-    
-
-.large-heading {
-    font-size: 40px; 
-    font-weight: bold; 
-    margin: 30px 0; 
-}
-
-p {
-    font-size: 12px; /* Adjust the size as needed */
-  }
-
 .main-content {
     flex: 1;
     display: flex;
     flex-direction: column;
 }
-
 footer {
     background-color: black;
     color: white;
-    padding: 20px 50px;
+    padding: 20px;
     display: flex;
-    justify-content: space-between;
+    justify-content: center; /* Centers the footer container within the footer */
     align-items: center;
 }
 
@@ -173,35 +109,43 @@ footer {
     width: 100%;
     height: 220px;
     display: flex;
-    justify-content: space-between;
+    justify-content: space-between; /* Adjust if necessary, maybe 'center' if you want everything centered */
     align-items: center;
 }
 
 .footer-logo {
-    width: 150px; /* Adjust size as needed */
-    height: 150px;
-    align-items: center;
-    margin-bottom: 50px;
+    width: 160px; /* Adjust size as needed */
+    height: 170px;
 }
 
 .footer-left, .footer-center, .footer-right {
-    flex: 1;
+    flex: 1; /* Adjust this value to control the space each section takes */
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
 }
 
+.footer-left {
+    margin-left: 40px;
+    margin-top:30px;
+}
+
+.footer-right {
+    margin-right: 20px;
+    margin-top:30px;
+}
+
+.footer-center {
+    align-items: center; /* Ensure center alignment for the logo and name */
+}
+
 .footer-center h2 {
-    margin: 0;
+    margin: 0; /* Ensure there are no margins affecting centering */
 }
 
-.footer-right p {
-    margin-right: 300px;
-    text-align: right;
-}
-
-.footer-left p{
-    margin-left: 300px;
-
+/* Remove large margins that could skew the alignment */
+.footer-right p, .footer-left p {
+    margin: 0; /* Reset margin to ensure even spacing and alignment */
+    text-align: center; /* Center align the text */
 }

--- a/frontend/src/components/Layout/Layout.js
+++ b/frontend/src/components/Layout/Layout.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, Outlet } from 'react-router-dom';
 import './Layout.css';  // Ensure your CSS file path is correct
 
-function Layout({ children }) {
+function Layout() {
     return (
         <div className="site-container">
             <header>
@@ -21,7 +21,9 @@ function Layout({ children }) {
                     </ul>
                 </nav>
             </header>
-            <main className="content">{children}</main>
+            <main className="content">
+                <Outlet />  
+            </main>
             <footer>
                 <div className="footer-container">
                     <div className="footer-left">
@@ -32,7 +34,7 @@ function Layout({ children }) {
                         <img src="/images/Logo.png" alt="Phoenix Ukraine Logo" className="footer-logo" />
                     </div>
                     <div className="footer-right">
-                        <p>Phone: 123-456-7890</p>
+                        <p>Phone: 123456789000</p>
                     </div>
                 </div>
             </footer>
@@ -41,3 +43,4 @@ function Layout({ children }) {
 }
 
 export default Layout;
+

--- a/frontend/src/components/News/News.js
+++ b/frontend/src/components/News/News.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function News() {
+    return (
+        <div>
+            <h1>News Page</h1>
+            <p>Latest news will be shown here.</p>
+        </div>
+    );
+}
+
+export default News;

--- a/frontend/src/components/Projects/Projects.js
+++ b/frontend/src/components/Projects/Projects.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Projects() {
+    return (
+        <div>
+            <h1>Projects Page</h1>
+            <p>Information about our projects will be displayed here.</p>
+        </div>
+    );
+}
+
+export default Projects;


### PR DESCRIPTION
### Made menu items clickable

- Ensured all pages correctly inherit common layout components from Layout.js, including the header, menu, and footer.
- Updated navigation links within the menu to be fully clickable and responsive, ensuring that a person will be redirected to a new page if they click on any of the menu items.


Note: This pull request also involves cleaning CSS code due to the fact that Home.css had unnecessary elements already implemented in Layout.css, and the other way around. 

<img width="1440" alt="Screen Shot 2024-09-25 at 11 22 30 AM" src="https://github.com/user-attachments/assets/2b74802b-8ad5-4bb9-ae92-70897c4cac59">
<img width="1440" alt="Screen Shot 2024-09-25 at 11 22 46 AM" src="https://github.com/user-attachments/assets/c1546344-d58f-41da-820a-dad40a6aefbf">
<img width="1440" alt="Screen Shot 2024-09-25 at 11 22 38 AM" src="https://github.com/user-attachments/assets/266b70ef-6738-4310-b1d6-6f43497b2d25">


https://github.com/user-attachments/assets/4aae903f-cdd1-4793-beb4-e510841c25e3


