### PR TITLE
Fixing News Scraping Algorithm (Bug: No news displayed)

### DIFF
--- a/backend/run.py
+++ b/backend/run.py
@@ -1,4 +1,6 @@
 from app import app
+from app import routes  
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/frontend/src/services/apiService.js
+++ b/frontend/src/services/apiService.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const BASE_URL = 'http://localhost:5000'; // For development, adjust for production
+const BASE_URL = 'http://127.0.0.1:5000'; // Use this for development
 
 // Fetch general data
 export const fetchData = async () => {
@@ -35,8 +35,6 @@ export const postData = async (data) => {
   }
 };
 
-// More API functions can be added here
-// Example: Fallback to last 3 articles (to be customized based on your setup)
 export const fetchFallbackNews = async () => {
   try {
     const response = await fetch('/api/last-three-articles');  // Replace with your endpoint


### PR DESCRIPTION
This pull request addresses a bug where no news articles were being displayed on the front end due to two main issues: a misconfiguration in apiService.js and inefficiencies in scraper.py.

### Changes to apiService.js:
- Updated the base URL from localhost:5000 to 127.0.0.1:5000, which resolves the issue with failed data fetching. This change helped me make sure that requests sent from the front end can reach the back end, displaying the news articles as intended.

### Improvements to scraper.py:

- **Issue:** Scraper.py often stored multiple instances of the same article due to minor variations in titles or URLs which basically cluttered the news feed and diminished its quality
-  **Solution:** I implemented a hashing mechanism where each article is assigned a unique identifier based on its title or URL. Before saving a new article, the script checks if this identifier already exists in article_data.json. If a duplicate is detected, it skips adding the article, ensuring that each entry is unique.
- **Issue:** The original scraping logic fetched articles without robust filtering, which resulted in some irrelevant or low-quality content making it to the feed.
- **Solution:** To improve the relevance, I added keyword-based filtering and adjusted the search criteria to prioritize sources with higher relevance to our target topics. This involved setting up a list of priority keywords (e.g., related to rebuilding Ukraine) and refining the criteria for what qualifies as a "relevant" article.
<img width="1433" alt="image" src="https://github.com/user-attachments/assets/fca8f461-9f31-4627-9113-7f1630d1b8a3">



