### PR TITLE
Fixing News Page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,7 @@
-import React from 'react';
+// App.js
+import React, { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { fetchNews, fetchFallbackNews } from './services/apiService';
 import Layout from './components/Layout/Layout';
 import Home from './components/Home/Home';
 import News from './components/News/News';
@@ -7,12 +9,30 @@ import Projects from './components/Projects/Projects';
 import About from './components/About/About';
 
 function App() {
+    const [news, setNews] = useState([]);
+
+    useEffect(() => {
+        const loadNews = async () => {
+            try {
+                let fetchedNews = await fetchNews();
+                if (!fetchedNews || fetchedNews.length === 0) {
+                    fetchedNews = await fetchFallbackNews();
+                }
+                setNews(fetchedNews.slice(0, 3)); // Limit to top 3 articles
+            } catch (error) {
+                console.error('Error fetching news:', error);
+            }
+        };
+
+        loadNews();
+    }, []);
+
     return (
         <Router>
             <Routes>
                 <Route path="/" element={<Layout />}>
-                    <Route index element={<Home />} />
-                    <Route path="news" element={<News />} />
+                    <Route index element={<Home news={news} />} /> {/* Pass news as props */}
+                    <Route path="news" element={<News news={news} />} /> {/* Pass news as props */}
                     <Route path="projects" element={<Projects />} />
                     <Route path="about" element={<About />} />
                 </Route>

--- a/frontend/src/components/Home/Home.js
+++ b/frontend/src/components/Home/Home.js
@@ -1,11 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { fetchData, fetchNews } from '../../services/apiService';  // Add fetchNews to handle news fetching
+import { fetchData } from '../../services/apiService';
+import { useFetchNews } from '../News/News';
 import './Home.css';
 import '../News/News.css';
 
 function Home() {
   const [data, setData] = useState({ title: '', description: '', links: [] });
-  const [news, setNews] = useState([]);  // State to store the latest news articles
+  const news = useFetchNews(); // Use custom hook to fetch the latest news
 
   useEffect(() => {
     const loadData = async () => {
@@ -17,17 +18,7 @@ function Home() {
       }
     };
 
-    const loadNews = async () => {
-      try {
-        const fetchedNews = await fetchNews();  // Fetch dynamic news data
-        setNews(fetchedNews);  // Set the fetched news into state
-      } catch (error) {
-        console.error('Error fetching news:', error);
-      }
-    };
-
     loadData();  // Fetch static data when the component mounts
-    loadNews();  // Fetch news data when the component mounts
   }, []);
 
   return (
@@ -50,26 +41,25 @@ function Home() {
         <h2>Latest News</h2>
         <div className="news-container">
           {news.length > 0 ? (
-          news.map((article, index) => (
-            <div key={index} className="news-item">
-              <img 
-                src={article.image || '/images/News.jpeg'}  
-                alt={`News ${index + 1}`} 
-                className="news-image" 
-              />
-              <div className="news-content">
-                <h4>{article.title}</h4>
-                <p>{article.summary}</p>
-                <p><strong>Published on:</strong> {new Date(article.publishedAt).toLocaleDateString('en-US', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                })}</p>
-                <a href={article.link} target="_blank" rel="noopener noreferrer">Read more</a>
+            news.map((article, index) => (
+              <div key={index} className="news-item">
+                <img 
+                  src={article.image || '/images/News.jpeg'}  
+                  alt={`News ${index + 1}`} 
+                  className="news-image" 
+                />
+                <div className="news-content">
+                  <h4>{article.title}</h4>
+                  <p>{article.summary}</p>
+                  <p><strong>Published on:</strong> {new Date(article.publishedAt).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}</p>
+                  <a href={article.link} target="_blank" rel="noopener noreferrer">Read more</a>
+                </div>
               </div>
-            </div>
-          ))
-
+            ))
           ) : (
             <p>No news available at the moment.</p>
           )}
@@ -103,4 +93,3 @@ function Home() {
 }
 
 export default Home;
-

--- a/frontend/src/components/Home/Home.js
+++ b/frontend/src/components/Home/Home.js
@@ -1,12 +1,11 @@
+// Home.js
 import React, { useEffect, useState } from 'react';
 import { fetchData } from '../../services/apiService';
-import { useFetchNews } from '../News/News';
 import './Home.css';
 import '../News/News.css';
 
-function Home() {
+function Home({ news }) {
   const [data, setData] = useState({ title: '', description: '', links: [] });
-  const news = useFetchNews(); // Use custom hook to fetch the latest news
 
   useEffect(() => {
     const loadData = async () => {

--- a/frontend/src/components/News/News.js
+++ b/frontend/src/components/News/News.js
@@ -1,32 +1,31 @@
 import React, { useState, useEffect } from 'react';
 import { fetchNews, fetchFallbackNews } from '../../services/apiService';
 
-function News() {
-  const [news, setNews] = useState([]);  // State to store the latest news articles
+// Custom hook to fetch news data
+const useFetchNews = () => {
+  const [news, setNews] = useState([]);
 
   useEffect(() => {
     const loadNews = async () => {
       try {
-        // Attempt to fetch the latest news
         let fetchedNews = await fetchNews();
-        console.log("Fetched latest news:", fetchedNews);
-
-        // If no articles are returned, attempt to fetch fallback news
         if (!fetchedNews || fetchedNews.length === 0) {
-          console.log("No new articles found. Fetching fallback news.");
           fetchedNews = await fetchFallbackNews();
-          console.log("Fetched fallback news:", fetchedNews);
         }
-
-        // Set the fetched or fallback news into state
-        setNews(fetchedNews);
+        setNews(fetchedNews.slice(0, 3)); // Limit to 3 articles
       } catch (error) {
         console.error('Error fetching news:', error);
       }
     };
 
-    loadNews();  // Fetch news data when the component mounts
-  }, []);  // Empty dependency array ensures it runs only once on mount
+    loadNews();
+  }, []);
+
+  return news;
+};
+
+function News() {
+  const news = useFetchNews();
 
   return (
     <div className="news-section">
@@ -61,5 +60,5 @@ function News() {
   );
 }
 
+export { useFetchNews };
 export default News;
-

--- a/frontend/src/components/News/News.js
+++ b/frontend/src/components/News/News.js
@@ -1,32 +1,7 @@
-import React, { useState, useEffect } from 'react';
-import { fetchNews, fetchFallbackNews } from '../../services/apiService';
+// News.js
+import React from 'react';
 
-// Custom hook to fetch news data
-const useFetchNews = () => {
-  const [news, setNews] = useState([]);
-
-  useEffect(() => {
-    const loadNews = async () => {
-      try {
-        let fetchedNews = await fetchNews();
-        if (!fetchedNews || fetchedNews.length === 0) {
-          fetchedNews = await fetchFallbackNews();
-        }
-        setNews(fetchedNews.slice(0, 3)); // Limit to 3 articles
-      } catch (error) {
-        console.error('Error fetching news:', error);
-      }
-    };
-
-    loadNews();
-  }, []);
-
-  return news;
-};
-
-function News() {
-  const news = useFetchNews();
-
+function News({ news }) {
   return (
     <div className="news-section">
       <h2>Latest News</h2>
@@ -42,7 +17,6 @@ function News() {
               <div className="news-content">
                 <h4>{article.title}</h4>
                 <p>{article.summary}</p>
-                <p><strong>Sentiment:</strong> {article.sentiment > 0 ? 'Positive' : article.sentiment < 0 ? 'Negative' : 'Neutral'}</p>
                 <p><strong>Published on:</strong> {new Date(article.publishedAt).toLocaleDateString('en-US', {
                   year: 'numeric',
                   month: 'long',
@@ -60,5 +34,4 @@ function News() {
   );
 }
 
-export { useFetchNews };
 export default News;


### PR DESCRIPTION
This pull request updates App.js, Home.js, and News.js to make sure both the Home and News pages display the same three latest news articles.

### App.js:
- Added a news state that fetches and stores the latest three articles.
- Passed news as props to Home and News so both pages use the same data.

### Home.js:
- Removed the separate news fetch and now pulls news as a prop from App.js.


### News.js:
- Updated to receive news as a prop, keeping the News page in sync with the Home page.


This change allows to reduce duplicate API calls and ensures both pages always display the same top news items for a consistent experience.

### Home page "Latest News" Section
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/027fc4ee-f65d-49a6-ac61-47938f2757a3">

### News Page
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/d733f58e-8022-4237-bc60-3171f0b8ede2">
