### PR TITLE
Adding History of Destruction of Each Bridge 

### DIFF
--- a/backend/app/data/bridges.json
+++ b/backend/app/data/bridges.json
@@ -8,7 +8,8 @@
       "Volume": 3200,
       "Total Area of the Damage": 185.437,
       "Latitude": 48.59326858376143, 
-      "Longitude": 37.98628138529925
+      "Longitude": 37.98628138529925, 
+      "Deconstruction History": "The Bakhmut Rail Bridge was destroyed by Ukrainian forces on December 11, 2022, to impede Russian advances toward Sloviansk. This strategic demolition aimed to disrupt Russian supply lines and hinder their military operations in the region. The destruction of the bridge was part of broader efforts to defend Bakhmut and its surroundings during the ongoing conflict. By severing this critical connection, Ukrainian forces sought to limit Russian mobility and reinforce their defensive positions."
   },
   {
       "Bridge ID": "ID013",
@@ -19,7 +20,8 @@
       "Volume": 6800,
       "Total Area of the Damage": 629.28,
       "Latitude": 48.86906001565378, 
-      "Longitude": 38.093442222102865
+      "Longitude": 38.093442222102865,
+      "Deconstruction History": "The Siverskyi Donets River Bridge, near Bilohorivka, was destroyed by Ukrainian forces on May 8, 2022, to prevent Russian troops from advancing westward toward Lyman. Ukrainian artillery and airstrikes targeted a pontoon bridge constructed by Russian forces at Bilohorivka, leading to its destruction by May 10. This action resulted in significant Russian military losses, including the destruction of 30 vehicles and the disabling of 40 others."
   },
   {
       "Bridge ID": "ID021",
@@ -30,7 +32,8 @@
       "Volume": 8700,
       "Total Area of the Damage": 1392,
       "Latitude": 49.019111, 
-      "Longitude": 37.511322
+      "Longitude": 37.511322,
+      "Deconstruction History": "The Bohorodychne Bridge, spanning the Siverskyi Donets River in Ukraine's Donetsk region, was destroyed during the conflict in early 2022. On April 5, 2022, AFP reported that the bridge was blown up to impede Russian forces advancing toward the Donbas region."
   },
   {
       "Bridge ID": "ID015",
@@ -41,7 +44,8 @@
       "Volume": 8000,
       "Total Area of the Damage": 236.988,
       "Latitude": 50.075065, 
-      "Longitude": 36.791751
+      "Longitude": 36.791751,
+      "Deconstruction History": "The Staryi Saltiv Dam Bridge, spanning the Siverskyi Donets River near the town of Staryi Saltiv in Ukraine's Kharkiv region, was destroyed by Russian forces in May 2024. On May 11, Russian forces launched a Kh-38 air-to-surface missile at the bridge, utilizing an Orlan-30 UAV for targeting. This strategic strike aimed to sever Ukrainian supply lines and isolate forces defending the Vovchansk area. The destruction of the bridge significantly disrupted Ukrainian ground lines of communication, complicating troop movements and resupply efforts."
   },
   {
       "Bridge ID": "ID016",
@@ -52,7 +56,8 @@
       "Volume": 120,
       "Total Area of the Damage": 657.62,
       "Latitude": 50.142151, 
-      "Longitude": 36.260041
+      "Longitude": 36.260041,
+      "Deconstruction History": "The bridge near Rus'ka Lozova, a village north of Kharkiv, Ukraine, was destroyed during the early stages of the conflict in 2022. On May 16, 2022, The Wall Street Journal reported that the bridge was blown up to impede Russian forces advancing toward Kharkiv. Subsequent reports indicated that the village suffered substantial damage, with houses gutted by shells. "
   },
   {
       "Bridge ID": "ID020",
@@ -63,7 +68,8 @@
       "Volume": 3500,
       "Total Area of the Damage": 442.32,
       "Latitude": 49.343642, 
-      "Longitude": 37.525077
+      "Longitude": 37.525077,
+      "Deconstruction History": "The Horokhovatka Bridge, located near the village of Horokhovatka in Kharkiv Oblast, Ukraine, has been a focal point during the conflict. In October 2024, Russian forces reportedly dropped a 3,000 kg bomb on Ukrainian positions near the bridge, resulting in its destruction."
   },
   {
       "Bridge ID": "ID001",
@@ -74,7 +80,8 @@
       "Volume": 7600,
       "Total Area of the Damage": 2275,
       "Latitude": 46.669124, 
-      "Longitude": 32.719966
+      "Longitude": 32.719966,
+      "Deconstruction History": "In July 2022, Ukrainian forces targeted the bridge with HIMARS rockets, causing significant damage and disrupting Russian supply lines. By November 2022, as Russian forces retreated from Kherson, the bridge collapsed, likely due to prior damage and the withdrawal process."
   },
   {
       "Bridge ID": "ID005",
@@ -85,7 +92,8 @@
       "Volume": 8100,
       "Total Area of the Damage": 321.12,
       "Latitude": 45.989463, 
-      "Longitude": 34.549911
+      "Longitude": 34.549911,
+      "Deconstruction History": "The Chongar Bridge, connecting mainland Ukraine to the Crimean Peninsula, has been a strategic target during the ongoing conflict. On June 22, 2023, Ukrainian forces struck the bridge with missiles, causing significant damage and disrupting Russian supply lines. Subsequent attacks on July 29 and August 6, 2023, further impaired the bridge's functionality. These actions have complicated Russian logistics and transportation between Crimea and occupied regions of Ukraine."
   },
   {
       "Bridge ID": "ID009",
@@ -96,7 +104,8 @@
       "Volume": 9400,
       "Total Area of the Damage": 2043.3,
       "Latitude": 46.743442923888, 
-      "Longitude": 32.81138011895965
+      "Longitude": 32.81138011895965,
+      "Deconstruction History": "n July 2022, Ukrainian forces targeted the bridge with rocket and artillery strikes, rendering it unusable and disrupting Russian supply lines. Subsequently, on November 9, 2022, as Russian troops withdrew from the right bank of the Dnipro River, they detonated the bridge to impede Ukrainian advances."
   },
   {
       "Bridge ID": "ID011",
@@ -107,7 +116,8 @@
       "Volume": 5300,
       "Total Area of the Damage": 239.85,
       "Latitude": 46.17347271489504, 
-      "Longitude": 34.773030458917496
+      "Longitude": 34.773030458917496,
+      "Deconstruction History": "The Henichesk Bridge, connecting the Arabat Spit to mainland Ukraine, has been a strategic target during the conflict. On February 24, 2022, Ukrainian Marine Vitalii Skakun sacrificed his life to destroy the bridge, impeding Russian forces advancing from Crimea."
   },
   {
       "Bridge ID": "ID006",
@@ -118,7 +128,8 @@
       "Volume": 9500,
       "Total Area of the Damage": 145.116,
       "Latitude": 45.98830881278158, 
-      "Longitude": 34.5518644021722
+      "Longitude": 34.5518644021722,
+      "Deconstruction History": "The Second Chongar Bridge, also known as the Chonhar Bridge, is a vital infrastructure connecting mainland Ukraine to the Crimean Peninsula. On June 22, 2023, Ukrainian forces conducted a missile strike on the bridge, causing significant damage and disrupting Russian supply lines. "
   },
   {
       "Bridge ID": "ID003",
@@ -129,7 +140,8 @@
       "Volume": 2400,
       "Total Area of the Damage": 1175.72,
       "Latitude": 50.51082743234649, 
-      "Longitude": 30.258850904528572
+      "Longitude": 30.258850904528572,
+      "Deconstruction History": "The Irpin River Bridge, located near Kyiv, Ukraine, was strategically destroyed by Ukrainian forces on February 25, 2022, to impede the Russian advance toward the capital. This action effectively halted Russian troops from entering Kyiv via this route. In the aftermath, the destroyed bridge became a poignant symbol of the conflict. Civilians fleeing the area crossed the remnants of the bridge, seeking safety from the advancing forces. "
   },
   {
       "Bridge ID": "ID022",
@@ -140,7 +152,8 @@
       "Volume": 3300,
       "Total Area of the Damage": 273.76,
       "Latitude": 50.49502197170159, 
-      "Longitude": 31.138975081450454
+      "Longitude": 31.138975081450454,
+      "Deconstruction History": "The Rusaniv Bridge, spanning the Trubizh River near the village of Rusaniv in Kyiv Oblast, Ukraine, was strategically destroyed by Ukrainian forces in early 2022 to impede Russian military movements. On February 25, 2022, Ukrainian forces blew up the bridge to prevent Russian troops from advancing toward Kyiv. "
   },
   {
       "Bridge ID": "ID007",
@@ -151,7 +164,8 @@
       "Volume": 1800,
       "Total Area of the Damage": 254,
       "Latitude": 49.21620256184143, 
-      "Longitude": 38.185693173994984
+      "Longitude": 38.185693173994984,
+      "Deconstruction History": "The Krasna River Bridge, located near the village of Krasnorichenske in Luhansk Oblast, Ukraine, was destroyed by Russian forces on October 30, 2022. This action was taken to impede the advance of Ukraine's Armed Forces in the region."
   },
   {
       "Bridge ID": "ID010",
@@ -162,7 +176,8 @@
       "Volume": 7300,
       "Total Area of the Damage": 499.8,
       "Latitude": 48.92470068143135, 
-      "Longitude": 38.437059291858844
+      "Longitude": 38.437059291858844,
+      "Deconstruction History": "The Pavlograd Bridge, connecting Severodonetsk and Lysychansk in Ukraine's Luhansk region, was destroyed by Russian forces during the conflict. On June 11, 2022, satellite imagery revealed significant damage to the bridge, with parts of it lying in the Seversky Donets River, indicating its destruction."
   },
   {
       "Bridge ID": "ID017",
@@ -173,7 +188,8 @@
       "Volume": 9350,
       "Total Area of the Damage": 1542.8,
       "Latitude": 48.575530270269454, 
-      "Longitude": 39.2865461615068
+      "Longitude": 39.2865461615068,
+      "Deconstruction History": "n May 2022, Russian forces constructed a pontoon bridge near Bilohorivka to facilitate the movement of personnel and equipment. Ukrainian forces identified this crossing and launched a combined aerial and artillery strike, resulting in the destruction of the bridge and significant losses for the Russian military."
   },
   {
       "Bridge ID": "ID018",
@@ -184,7 +200,8 @@
       "Volume": 1200,
       "Total Area of the Damage": 349.305,
       "Latitude": 48.967391280916914, 
-      "Longitude":  38.46182281505272
+      "Longitude":  38.46182281505272,
+      "Deconstruction History": "The Borova Highway Bridge, located near the village of Borova in Kharkiv Oblast, Ukraine, was destroyed during the conflict. Reports indicate that Russian forces blew up the bridge to impede Ukrainian military movements."
   },
   {
       "Bridge ID": "ID019",
@@ -195,7 +212,8 @@
       "Volume": 2700,
       "Total Area of the Damage": 194.256,
       "Latitude":48.967105080202174, 
-      "Longitude": 38.46100295802945
+      "Longitude": 38.46100295802945,
+      "Deconstruction History": "The Borova Railway Bridge, located near the village of Borova in Kharkiv Oblast, Ukraine, was strategically destroyed during the conflict to impede Russian military movements. On April 14, 2022, reports indicated that Ukrainian forces blew up the bridge to prevent Russian troops from advancing toward Kharkiv."
   },
   {
       "Bridge ID": "ID008",
@@ -206,7 +224,8 @@
       "Volume": 950,
       "Total Area of the Damage": 455.52,
       "Latitude": 47.0000,
-      "Longitude": 31.9000
+      "Longitude": 31.9000,
+      "Deconstruction History": "The Snihurivka Canal Bridge, located near the settlement of Snihurivka in Mykolaiv Oblast, Ukraine, was destroyed during the conflict. On November 9, 2022, Russian forces blew up the bridge over the canal at the entrance to Snihurivka from the Kherson side."
   },
   {
       "Bridge ID": "ID012",
@@ -217,7 +236,8 @@
       "Volume": 6800,
       "Total Area of the Damage": 1287.44,
       "Latitude": 46.07633,
-      "Longitude":  30.46987
+      "Longitude":  30.46987,
+      "Deconstruction History": "The Zatoka Bridge, spanning the Dniester Estuary in Odesa Oblast, Ukraine, has been a strategic target during the conflict. On April 27, 2022, Russian forces launched missile strikes against the bridge, aiming to sever the connection between Odesa and the rest of Ukraine. Subsequent attacks occurred on October 30-31, 2024, when Russian troops fired 43 drones and missiles at the bridge. "
   },
   {
       "Bridge ID": "ID002",
@@ -228,7 +248,8 @@
       "Volume": 1900,
       "Total Area of the Damage": 592.76,
       "Latitude": 46.84216064913073, 
-      "Longitude": 35.40754765548516
+      "Longitude": 35.40754765548516,
+      "Deconstruction History": " In December 2022, Ukrainian forces reportedly damaged a key bridge over the Molochna River near Melitopol, a city in Zaporizhzhia Oblast. This bridge was vital for Russian supply lines, connecting Melitopol to nearby areas. The attack on the Molochna River bridge significantly disrupted Russian logistics, hindering the movement of troops and supplies in the region."
   },
   {
       "Bridge ID": "ID014",
@@ -239,6 +260,7 @@
       "Volume": 2900,
       "Total Area of the Damage": 1080.72,
       "Latitude": 46.971283, 
-      "Longitude": 35.441457
+      "Longitude": 35.441457,
+      "Deconstruction History": "The Starobohdanivka Railway Bridge, located near the village of Starobohdanivka in Zaporizhzhia Oblast, Ukraine, was strategically targeted during the conflict. On November 3, 2022, Ukrainian forces conducted a successful strike on the bridge, causing significant damage and disrupting Russian supply lines in the region."
   }
 ]

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -18,19 +18,8 @@ def get_data():
 @app.route("/api/news")
 def get_news():
     news = get_latest_articles()
-    
-    # Print each article in the terminal
-    # for idx, article in enumerate(news, start=1):
-    #     print(f"Article {idx}:")
-    #     print(f"Title       : {article['title']}")
-    #     print(f"Summary     : {article['summary']}")
-    #     print(f"Link        : {article['link']}")
-    #     print(f"Published At: {article['publishedAt']}")
-    #     print(f"Sentiment   : {'Positive' if article['sentiment'] > 0 else 'Negative' if article['sentiment'] < 0 else 'Neutral'}")
-    #     print(f"Weight      : {article['weight']:.2f}")
-    #     print("-" * 50)
-    
     return jsonify(news)
+
 
 
 @app.route("/api/bridges")

--- a/backend/app/scraper.py
+++ b/backend/app/scraper.py
@@ -37,9 +37,10 @@ def get_latest_articles():
     }
 
     response = requests.get(url, params=params)
+
     if response.status_code != 200:
         return []
-    
+
     articles = response.json().get('articles')
     return filter_and_diversify_articles(articles)
 
@@ -116,6 +117,7 @@ def get_article_topic(content):
 
 if __name__ == "__main__":
     latest_articles = get_latest_articles()
+    print(latest_articles)
     for article in latest_articles:
         print(json.dumps(article, indent=2))
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+flask
+flask-cors

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "axios": "^1.7.7",
         "leaflet": "^1.9.4",
         "react": "^18.3.1",
+        "react-card-flip": "^1.2.3",
         "react-dom": "^18.3.1",
         "react-leaflet": "^4.2.1",
         "react-router-dom": "^6.26.2",
@@ -14818,6 +14819,15 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
+    "node_modules/react-card-flip": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/react-card-flip/-/react-card-flip-1.2.3.tgz",
+      "integrity": "sha512-yb8+yyeTf5UVlZ/FC78XDgxYeWhgA0W28OXNB31LjiFeY1Y2kFhLP7bFiED4KNaRWKjaafT74G38XU53a6eIuw==",
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
     },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "axios": "^1.7.7",
     "leaflet": "^1.9.4",
     "react": "^18.3.1",
+    "react-card-flip": "^1.2.3",
     "react-dom": "^18.3.1",
     "react-leaflet": "^4.2.1",
     "react-router-dom": "^6.26.2",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,18 +16,22 @@ function App() {
         const loadNews = async () => {
             try {
                 let fetchedNews = await fetchNews();
+                console.log("Fetched News:", fetchedNews);  // Log fetched news data
+    
                 if (!fetchedNews || fetchedNews.length === 0) {
+                    console.log("Fallback news used");  // Indicate when fallback is used
                     fetchedNews = await fetchFallbackNews();
                 }
+    
                 setNews(fetchedNews.slice(0, 3)); // Limit to top 3 articles
             } catch (error) {
                 console.error('Error fetching news:', error);
             }
         };
-
+    
         loadNews();
     }, []);
-
+    
     return (
         <Router>
             <Routes>

--- a/frontend/src/components/RegionPage/RegionPage.css
+++ b/frontend/src/components/RegionPage/RegionPage.css
@@ -117,12 +117,39 @@
 
 .bridge-card {
     background-color: #333;
+    position: relative;
     padding: 20px; 
     border-radius: 5px;
     width: 300px;
     color: white;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.3); 
     transition: transform 0.2s, box-shadow 0.2s; 
+}
+.info-icon {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    font-size: 18px;
+    cursor: pointer;
+    color: white;
+    padding: 5px;
+    border-radius: 50%;
+    transition: background-color 0.3s;
+}
+
+.info-icon:hover {
+    background-color: #555;
+}
+
+.bridge-info, .bridge-history {
+    margin-top: 10px;
+}
+
+.bridge-history {
+    background-color: #444;
+    padding: 10px;
+    border-radius: 5px;
+    margin-top: 25px;
 }
 
 .bridge-card:hover {

--- a/frontend/src/components/RegionPage/RegionPage.css
+++ b/frontend/src/components/RegionPage/RegionPage.css
@@ -19,12 +19,14 @@
 }
 
 .region-image {
-    width: 600px;
-    height: 400px;
+    width: 700px;
+    height: 500px;
     object-fit: cover;
     border-radius: 8px;
-    margin-left: 40px;
+    margin-left: 60px;
+    margin-right: -50px;
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+    margin-top: 30px;
 }
 
 .region-images {
@@ -150,6 +152,7 @@
     padding: 10px;
     border-radius: 5px;
     margin-top: 25px;
+    line-height: 1.8;
 }
 
 .bridge-card:hover {

--- a/frontend/src/components/RegionPage/RegionPage.js
+++ b/frontend/src/components/RegionPage/RegionPage.js
@@ -12,6 +12,9 @@ function RegionPage() {
     const [showMatrix, setShowMatrix] = useState(null);
     const [selectedAnswer, setSelectedAnswer] = useState(null);
     const [showExplanation, setShowExplanation] = useState(false);
+    const [selectedBridgeId, setSelectedBridgeId] = useState(null); // Track which card is toggled
+
+
 
     const staticImages = {
         'donetsk': '/images/static1.jpg',
@@ -127,6 +130,7 @@ function RegionPage() {
             prevIndex === explanationCards.length - 1 ? 0 : prevIndex + 1
         );
     };
+    
 
     useEffect(() => {
         console.log('Current regionId:', regionId);
@@ -145,6 +149,11 @@ function RegionPage() {
 
         fetchRegionData();
     }, [regionId]);
+
+    const handleToggleInfo = (bridgeId) => {
+        setSelectedBridgeId(prevId => (prevId === bridgeId ? null : bridgeId)); // Toggle selected bridge info
+    };
+
 
     const renderStepContent = () => {
         const step = ahpSteps[activeStep];
@@ -325,6 +334,11 @@ function RegionPage() {
                 <div className="bridge-cards">
                     {bridges.map((bridge) => (
                         <div key={bridge["Bridge ID"]} className="bridge-card">
+                            <div className="card-content">
+                                {/* Info Icon */}
+                                <div className="info-icon" onClick={() => handleToggleInfo(bridge["Bridge ID"])}>ℹ️</div>
+
+                                {/* Card front */}
                             <img src={`/images/${bridge["Bridge ID"]}.jpg`} alt={bridge["Bridge Name"]} />
                             <div className="tooltip-container">
                                 <div className={`rank-badge rank-${bridge["Rank"]}`}>
@@ -337,10 +351,19 @@ function RegionPage() {
                             <h3>#{bridge["Rank"]} {bridge["Bridge Name"]}</h3> 
                             <p><strong>Function:</strong> {bridge["Bridge Function"]}</p>
                             <p><strong>Reconstruction Cost:</strong> €{bridge["Reconstruction Costs"].toLocaleString()}</p>
-                            <p><strong>Volume:</strong> {bridge["Volume"]}</p>
                             <p><strong>Total Area of Damage:</strong> {bridge["Total Area of the Damage"]} m²</p>
+                            <p><strong>Average Traffic Volume:</strong> {bridge["Volume"]} cars/day</p>
+
                             <p><strong>AHP Score:</strong> {bridge["AHP Score"].toFixed(4)}</p> 
                         </div>
+                            {/* Toggle Content */}
+                            {selectedBridgeId === bridge["Bridge ID"] && (
+                            <div className="bridge-history">
+                                <h4>History of Deconstruction</h4>
+                                <p>{bridge["Deconstruction History"] || "No history available for this bridge."}</p>
+                            </div>
+                        )}
+                    </div>
                     ))}
                 </div>
             </section>

--- a/frontend/src/components/RegionPage/RegionPage.js
+++ b/frontend/src/components/RegionPage/RegionPage.js
@@ -348,7 +348,7 @@ function RegionPage() {
                                     Rank {bridge["Rank"]}: Based on AHP score considering traffic volume, reconstruction costs, and function.
                                 </span>
                             </div>
-                            <h3>#{bridge["Rank"]} {bridge["Bridge Name"]}</h3> 
+                            <h3>{bridge["Bridge Name"]}</h3> 
                             <p><strong>Function:</strong> {bridge["Bridge Function"]}</p>
                             <p><strong>Reconstruction Cost:</strong> €{bridge["Reconstruction Costs"].toLocaleString()}</p>
                             <p><strong>Total Area of Damage:</strong> {bridge["Total Area of the Damage"]} m²</p>

--- a/frontend/src/services/apiService.js
+++ b/frontend/src/services/apiService.js
@@ -13,16 +13,17 @@ export const fetchData = async () => {
   }
 };
 
-// Fetch latest news
 export const fetchNews = async () => {
   try {
     const response = await axios.get(`${BASE_URL}/api/news`);
+    console.log('Fetched news:', response.data);  // Log the fetched news data
     return response.data;
   } catch (error) {
     console.error('Error fetching news:', error);
     throw error; // Rethrow to handle it in the component
   }
 };
+
 
 // Example for posting data
 export const postData = async (data) => {
@@ -37,11 +38,11 @@ export const postData = async (data) => {
 
 export const fetchFallbackNews = async () => {
   try {
-    const response = await fetch('/api/last-three-articles');  // Replace with your endpoint
-    const fallbackNews = await response.json();
-    return fallbackNews;
+    const response = await axios.get(`${BASE_URL}/api/news`);  // Use /api/news here as well
+    return response.data;
   } catch (error) {
     console.error('Error fetching fallback news:', error);
     return [];  // Return an empty array if there is an error
   }
 };
+


### PR DESCRIPTION
This pull request introduces a new feature that allows users to view additional information about the history of destruction for each bridge. Below are the key changes:

### Info Icon:
- Added an info icon (ℹ️) to the top right corner of each bridge card.
- When clicked, the icon toggles the visibility of the History of Destruction for the selected bridge, revealing more details on how the bridge was damaged.

### Toggle Mechanism:
- Implemented a state management system that toggles the display of the destruction history based on which bridge card is selected.
- The content for the history is shown/hidden dynamically when the user clicks on the info icon.

### Bridge History in JSON:
- Integrated the History of Destruction as a new field in the bridge data JSON file.
- Each bridge now has a Reconstruction History key containing a detailed description of how the bridge was destroyed, providing users with in-depth context about the damage.

These updates help improve user experience by making the information accessible without flipping cards or overwhelming the user with too much content upfront. 

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/dc7565c3-e6f0-4ab4-88e6-4edff5d7edc9" />
<img width="1085" alt="image" src="https://github.com/user-attachments/assets/c2c9139c-a0dc-407e-adf6-61f56ca2986f" />


